### PR TITLE
chore: Update allowed headers in CORS configuration

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,12 @@ async function bootstrap() {
       cors({
         origin: getCorsOrigin(),
         method: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
-        allowedHeaders: ['Content-Type', 'Authorization'],
+        allowedHeaders: [
+          'Content-Type',
+          'Authorization',
+          'Cookie',
+          'Set-Cookie',
+        ],
         credentials: true,
       }),
     );


### PR DESCRIPTION
The allowed headers in the CORS configuration have been updated to include 'Cookie' and 'Set-Cookie'. This change ensures that cookies can be sent and received in cross-origin requests.